### PR TITLE
修复了标志位复用造成的Node被删除问题

### DIFF
--- a/EntryPoint.m
+++ b/EntryPoint.m
@@ -1,0 +1,87 @@
+ObstList = []; % Obstacle point list
+
+for i = -25:25
+    ObstList(end+1,:) = [i,30];
+end
+for i = -10:10
+    ObstList(end+1,:) = [i, 0];
+end
+for i = -25:-10
+    ObstList(end+1,:) = [i, 5];
+end
+for i = 10:25
+    ObstList(end+1,:) = [i, 5];
+end
+for i = 0:5
+    ObstList(end+1,:) = [10, i];
+end
+for i = 0:5
+    ObstList(end+1,:) = [-10, i];
+end
+
+ObstLine = []; % Park lot line for collision check
+tLine = [-25, 30 , 25, 30]; %start_x start_y end_x end_y
+ObstLine(end+1,:) = tLine;
+tLine = [-25, 5, -10, 5];
+ObstLine(end+1,:) = tLine;
+tLine = [-10, 5, -10, 0];
+ObstLine(end+1,:) = tLine;
+tLine = [-10, 0, 10, 0];
+ObstLine(end+1,:) = tLine;
+tLine = [10, 0, 10, 5];
+ObstLine(end+1,:) = tLine;
+tLine = [10, 5, 25, 5];
+ObstLine(end+1,:) = tLine;
+tLine = [-25, 5, -25, 30];
+ObstLine(end+1,:) = tLine;
+tLine = [25, 5, 25, 30];
+ObstLine(end+1,:) = tLine;
+
+Vehicle.WB = 3.7;  % [m] wheel base: rear to front steer
+Vehicle.W = 2.6; % [m] width of vehicle
+Vehicle.LF = 4.5; % [m] distance from rear to vehicle front end of vehicle
+Vehicle.LB = 1.0; % [m] distance from rear to vehicle back end of vehicle
+Vehicle.MAX_STEER = 0.6; % [rad] maximum steering angle 
+Vehicle.MIN_CIRCLE = Vehicle.WB/tan(Vehicle.MAX_STEER); % [m] mininum steering circle radius
+
+% ObstList and ObstLine
+Configure.ObstList = ObstList;
+Configure.ObstLine = ObstLine;
+
+% Motion resolution define
+Configure.MOTION_RESOLUTION = 0.1; % [m] path interporate resolution
+Configure.N_STEER = 20.0; % number of steer command
+Configure.EXTEND_AREA = 0; % [m] map extend length
+Configure.XY_GRID_RESOLUTION = 2.0; % [m]
+Configure.YAW_GRID_RESOLUTION = deg2rad(15.0); % [rad]
+% Grid bound
+Configure.MINX = min(ObstList(:,1))-Configure.EXTEND_AREA;
+Configure.MAXX = max(ObstList(:,1))+Configure.EXTEND_AREA;
+Configure.MINY = min(ObstList(:,2))-Configure.EXTEND_AREA;
+Configure.MAXY = max(ObstList(:,2))+Configure.EXTEND_AREA;
+Configure.MINYAW = -pi;
+Configure.MAXYAW = pi;
+% Cost related define
+Configure.SB_COST = 0; % switch back penalty cost
+Configure.BACK_COST = 1.5; % backward penalty cost
+Configure.STEER_CHANGE_COST = 1.5; % steer angle change penalty cost
+Configure.STEER_COST = 1.5; % steer angle change penalty cost
+Configure.H_COST = 10; % Heuristic cost
+% 
+% Start = [-15, 13, 0];
+% End = [0, 13, pi];
+
+Start = [22, 12, pi];
+End = [7, 13, -pi/2];
+
+% 使用完整约束有障碍情况下用A*搜索的最短路径最为hybrid A*的启发值
+ObstMap = GridAStar(Configure.ObstList,End,Configure.XY_GRID_RESOLUTION);
+Configure.ObstMap = ObstMap;
+cla %  从当前坐标区删除包含可见句柄的所有图形对象。
+[x,y,th,D,delta] = HybridAStar(Start,End,Vehicle,Configure);
+% GridAStar(ObstList,End,2);
+if isempty(x)
+    disp("Failed to find path!")
+else
+    VehicleAnimation(x,y,th,Configure,Vehicle)
+end

--- a/FindRSPath.m
+++ b/FindRSPath.m
@@ -1,0 +1,693 @@
+% path = FindRSPath(5,1,pi);
+
+
+function path = FindRSPath(x,y,phi,veh)
+    rmin = veh.MIN_CIRCLE; %minimum turning radius
+    x = x/rmin;
+    y = y/rmin;
+    % 遍历5种方法到达目标点，然后选取路径最短的一条
+    [isok1,path1] = CSC(x,y,phi);
+    [isok2,path2] = CCC(x,y,phi);
+    [isok3,path3] = CCCC(x,y,phi);
+    [isok4,path4] = CCSC(x,y,phi);
+    [isok5,path5] = CCSCC(x,y,phi);
+    isoks = [isok1, isok2, isok3, isok4, isok5];
+    paths = {path1, path2, path3, path4, path5};
+    Lmin = inf;
+    % 找出5条路径最短的曲线
+    for i = 1:5
+        if isoks(i) == true
+            elem = paths{i};
+            if Lmin > elem.totalLength
+                Lmin = elem.totalLength;
+                path = elem;
+            end
+        end
+    end
+%     PlotPath(path,veh);
+end
+
+% 控制角度x取值范围是[-pi,pi]
+function v = mod2pi(x)
+    v = rem(x,2*pi);
+    if v < -pi
+        v = v+2*pi;
+    elseif v > pi
+        v = v-2*pi;
+    end
+end
+
+% formula 8.6
+function [tau,omega] = tauOmega(u,v,xi,eta,phi)
+    delta = mod2pi(u-v);
+    A = sin(u)-sin(delta);
+    B = cos(u)-cos(delta)-1;
+    t1 = atan2(eta*A-xi*B,xi*A+eta*B);
+    t2 = 2*(cos(delta)-2*cos(v)-2*cos(u))+3;
+    if t2 < 0
+        tau = mod2pi(t1+pi);
+    else
+        tau = mod2pi(t1);
+    end
+    omega = mod2pi(tau-u+v-phi);
+end
+
+% formula 8.1
+function [isok,t,u,v] = LpSpLp(x,y,phi)
+    [t,u] = cart2pol(x-sin(phi),y-1+cos(phi)); % 将笛卡尔坐标转换为极坐标,返回theta和rho,论文返回的是[u,t],是因为cart2pol函数返回的值的顺序不同导致与原文不同，变量代表的含义还是一样，t代表弧度，u代表直行的距离
+    if t >= 0 % 必须是左转,t>=0代表左转
+        v = mod2pi(phi-t);
+        if v >= 0 % 符号代表前进和后退
+            isok = true;
+            return
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+% formula 8.2
+function [isok,t,u,v] = LpSpRp(x,y,phi)
+    [t1,u1] = cart2pol(x+sin(phi),y-1-cos(phi));
+    if u1^2 >= 4
+        u = sqrt(u1^2-4);
+        theta = atan2(2,u);
+        t = mod2pi(t1+theta);
+        v = mod2pi(t-phi);
+        if t >= 0 && v >= 0 % 符号代表前进和后退
+            isok = true;
+            return
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+function [isok,path] = CSC(x,y,phi)
+    Lmin = inf;
+    type = repmat('N',[1,5]);
+    path = RSPath(type,0,0,0,0,0);
+    [isok,t,u,v] = LpSpLp(x,y,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(15,:),t,u,v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpLp(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(15,:),-t,-u,-v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpLp(x,-y,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(16,:),t,u,v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpLp(-x,-y,phi); % timeflp + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(16,:),-t,-u,-v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpRp(x,y,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(13,:),t,u,v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpRp(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(13,:),-t,-u,-v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpRp(x,-y,-phi); % reflect 
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(14,:),t,u,v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpSpRp(-x,-y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(14,:),-t,-u,-v,0,0);
+        end
+    end
+    if Lmin == inf
+        isok = false;
+    else
+        isok = true;
+    end
+end
+
+% formula 8.3/8.4
+function [isok,t,u,v] = LpRmL(x,y,phi)
+    xi = x-sin(phi);
+    eta = y-1+cos(phi);
+    [theta,u1] = cart2pol(xi,eta);
+    if u1 <= 4
+        u = -2*asin(u1/4);
+        t = mod2pi(theta+u/2+pi);
+        v = mod2pi(phi-t+u);
+        if t >= 0 && u <= 0
+            isok = true;
+            return
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+function [isok,path] = CCC(x,y,phi)
+    Lmin = inf;
+    type = repmat('N',[1,5]);
+    path = RSPath(type,0,0,0,0,0);
+    [isok,t,u,v] = LpRmL(x,y,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(1,:),t,u,v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpRmL(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(1,:),-t,-u,-v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpRmL(x,-y,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(2,:),t,u,v,0,0);
+        end
+    end
+    [isok,t,u,v] = LpRmL(-x,-y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(2,:),-t,-u,-v,0,0);
+        end
+    end
+    % backwards
+    xb = x*cos(phi)+y*sin(phi);
+    yb = x*sin(phi)-y*cos(phi);
+    [isok,t,u,v] = LpRmL(xb,yb,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(1,:),v,u,t,0,0);
+        end
+    end
+    [isok,t,u,v] = LpRmL(-xb,yb,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(1,:),-v,-u,-t,0,0);
+        end
+    end
+    [isok,t,u,v] = LpRmL(xb,-yb,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(2,:),v,u,t,0,0);
+        end
+    end
+    [isok,t,u,v] = LpRmL(-xb,-yb,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(2,:),-v,-u,-t,0,0);
+        end
+    end
+    if Lmin == inf
+        isok = false;
+    else
+        isok = true;
+    end
+end
+
+% formula 8.7,tauOmega() is formula 8.6
+function [isok,t,u,v] = LpRupLumRm(x,y,phi)
+    xi = x+sin(phi);
+    eta = y-1-cos(phi);
+    rho = (2+sqrt(xi^2+eta^2))/4;
+    if rho <= 1
+        u = acos(rho);
+        [t,v] = tauOmega(u,-u,xi,eta,phi);
+        if t >= 0 && v <= 0 % 符号代表前进和后退
+            isok = true;
+            return
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+% formula 8.8
+function [isok,t,u,v] = LpRumLumRp(x,y,phi)
+    xi = x+sin(phi);
+    eta = y-1-cos(phi);
+    rho = (20-xi^2-eta^2)/16;
+    if rho >= 0 && rho <= 1
+        u = -acos(rho);
+        if u >= pi/2
+            [t,v] = tauOmega(u,u,xi,eta,phi);
+            if t >=0 && v >=0
+                isok = true;
+                return
+            end
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+function [isok,path] = CCCC(x,y,phi)
+    Lmin = inf;
+    type = repmat('N',[1,5]);
+    path = RSPath(type,0,0,0,0,0);
+    [isok,t,u,v] = LpRupLumRm(x,y,phi);
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(3,:),t,u,-u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRupLumRm(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(3,:),-t,-u,u,-v,0);
+        end
+    end
+    [isok,t,u,v] = LpRupLumRm(x,-y,-phi); % reflect
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(4,:),t,u,-u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRupLumRm(-x,-y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(4,:),-t,-u,u,-v,0);
+        end
+    end
+    [isok,t,u,v] = LpRumLumRp(x,y,phi);
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(3,:),t,u,u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRumLumRp(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(3,:),-t,-u,-u,-v,0);
+        end
+    end
+    [isok,t,u,v] = LpRumLumRp(x,-y,-phi); % reflect
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(4,:),t,u,u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRumLumRp(-x,-y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+2*abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(4,:),-t,-u,-u,-v,0);
+        end
+    end
+    if Lmin == inf
+        isok = false;
+    else
+        isok = true;
+    end
+end
+
+% formula 8.9
+function [isok,t,u,v] = LpRmSmLm(x,y,phi)
+    xi = x-sin(phi);
+    eta = y-1+cos(phi);
+    [theta,rho] = cart2pol(xi,eta);
+    if rho >= 2
+        r = sqrt(rho^2-4);
+        u = 2-r;
+        t = mod2pi(theta+atan2(r,-2));
+        v = mod2pi(phi-pi/2-t);
+        if t >= 0 && u <= 0 && v <= 0
+            isok = true;
+            return
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+% formula 8.10
+function [isok,t,u,v] = LpRmSmRm(x,y,phi)
+    xi = x+sin(phi);
+    eta = y-1-cos(phi);
+    [theta,rho] = cart2pol(-eta,xi);
+    if rho >= 2
+        t = theta;
+        u = 2-rho;
+        v = mod2pi(t+pi/2-phi);
+        if t >= 0 && u <= 0 && v <= 0
+            isok = true;
+            return
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+function [isok,path] = CCSC(x,y,phi)
+    Lmin = inf;
+    type = repmat('N',[1,5]);
+    path = RSPath(type,0,0,0,0,0);
+    [isok,t,u,v] = LpRmSmLm(x,y,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(5,:),t,-pi/2,u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmLm(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(5,:),-t,pi/2,-u,-v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmLm(x,-y,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(6,:),t,-pi/2,u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmLm(-x,-y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(6,:),-t,pi/2,-u,-v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(x,y,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(9,:),t,-pi/2,u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(-x,y,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(9,:),-t,pi/2,-u,-v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(x,-y,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(10,:),t,-pi/2,u,v,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(-x,-y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(10,:),-t,pi/2,-u,-v,0);
+        end
+    end
+    % backwards
+    xb = x*cos(phi)+y*sin(phi);
+    yb = x*sin(phi)-y*cos(phi);
+    [isok,t,u,v] = LpRmSmLm(xb,yb,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(7,:),v,u,-pi/2,t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmLm(-xb,yb,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(7,:),-v,-u,pi/2,-t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmLm(xb,-yb,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(8,:),v,u,-pi/2,t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmLm(-xb,-yb,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(8,:),-v,-u,pi/2,-t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(xb,yb,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(11,:),v,u,-pi/2,t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(-xb,yb,-phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(11,:),-v,-u,pi/2,-t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(xb,-yb,-phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(12,:),v,u,-pi/2,t,0);
+        end
+    end
+    [isok,t,u,v] = LpRmSmRm(-xb,-yb,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(12,:),-v,-u,pi/2,-t,0);
+        end
+    end
+    if Lmin == inf
+        isok = false;
+    else
+        isok = true;
+    end
+end
+
+% formula 8.11
+function [isok,t,u,v] = LpRmSLmRp(x,y,phi)
+    xi = x+sin(phi);
+    eta = y-1-cos(phi);
+    [~,rho] = cart2pol(xi,eta);
+    if rho >= 2
+        u = 4-sqrt(rho^2-4);
+        if u <= 0
+            t = mod2pi(atan2((4-u)*xi-2*eta,-2*xi+(u-4)*eta));
+            v = mod2pi(t-phi);
+            if t >= 0 && v >= 0
+                isok = true;
+                return
+            end
+        end
+    end
+    isok = false;
+    t = 0;
+    u = 0;
+    v = 0;
+end
+
+function [isok,path] = CCSCC(x,y,phi)
+    Lmin = inf;
+    type = repmat('N',[1,5]);
+    path = RSPath(type,0,0,0,0,0);
+    [isok,t,u,v] = LpRmSLmRp(x,y,phi);
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(17,:),t,-pi/2,u,-pi/2,v);
+        end
+    end
+    [isok,t,u,v] = LpRmSLmRp(x,y,phi); % timeflip
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(17,:),-t,pi/2,-u,pi/2,-v);
+        end
+    end
+    [isok,t,u,v] = LpRmSLmRp(x,y,phi); % reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(18,:),t,-pi/2,u,-pi/2,v);
+        end
+    end
+    [isok,t,u,v] = LpRmSLmRp(x,y,phi); % timeflip + reflect
+    if isok
+        L = abs(t)+abs(u)+abs(v);
+        if Lmin > L
+            Lmin = L;
+            path = RSPath(RSPath.Types(18,:),-t,pi/2,-u,pi/2,-v);
+        end
+    end
+    if Lmin == inf
+        isok = false;
+    else
+        isok = true;
+    end
+end
+
+function PlotPath(path,veh)
+    rmin = veh.MIN_CIRCLE;
+    type = path.type;
+    x = [];
+    y = [];
+    seg = [path.t,path.u,path.v,path.w,path.x];
+    pvec = [0,0,0];
+    for i = 1:5        
+        if type(i) == 'S'
+            theta = pvec(3);
+            dl = rmin*seg(i);
+            dvec = [dl*cos(theta), dl*sin(theta), 0];
+            dx = pvec(1)+linspace(0,dvec(1));
+            dy = pvec(2)+linspace(0,dvec(2));
+            x = [x,dx];
+            y = [y,dy];
+            pvec = pvec+dvec;
+        elseif type(i) == 'L'
+            theta = pvec(3);
+            dtheta = seg(i);
+            cenx = pvec(1)-rmin*sin(theta);
+            ceny = pvec(2)+rmin*cos(theta);
+            t = theta-pi/2+linspace(0,dtheta);
+            dx = cenx+rmin*cos(t);
+            dy = ceny+rmin*sin(t);
+            x = [x,dx];
+            y = [y,dy];
+            theta = theta+dtheta;
+            pvec = [dx(end),dy(end),theta];
+            dl = dtheta;
+        elseif type(i) == 'R'
+            theta = pvec(3);
+            dtheta = -seg(i);
+            cenx = pvec(1)+rmin*sin(theta);
+            ceny = pvec(2)-rmin*cos(theta);
+            t = theta+pi/2+linspace(0,dtheta);
+            dx = cenx+rmin*cos(t);
+            dy = ceny+rmin*sin(t);
+            x = [x,dx];
+            y = [y,dy];
+            theta = theta+dtheta;
+            pvec = [dx(end),dy(end),theta];
+            dl = -dtheta;
+        else
+            % do nothing
+        end
+        if dl > 0
+            plot(dx,dy,'b');
+        else
+            plot(dx,dy,'r');
+        end
+        hold on
+    end
+    axis equal
+    plot(0,0,'kx','LineWidth',2,'MarkerSize',10)
+    plot(x(end),y(end),'ko', 'LineWidth',2,'MarkerSize',10)
+    veh = plot(x(1),y(1),'d','MarkerFaceColor','g','MarkerSize',10);
+    writeVideo(videoFWriter,getframe);
+    hold off
+    pause(1)
+    for k = 2:length(x)
+        veh.XData = x(k);
+        veh.YData = y(k);
+        dl = norm([x(k)-x(k-1),y(k)-y(k-1)]);
+        writeVideo(videoFWriter,getframe);
+        pause(dl)
+    end    
+end

--- a/GridAStar.m
+++ b/GridAStar.m
@@ -1,0 +1,130 @@
+function costmap = GridAStar(obstlist,goal,gres)
+    [minx,miny,obmap] = CalcObstMap(obstlist,gres);
+    col = goal(1);
+    row = goal(2);
+    col = ceil((col-minx)/gres);
+    row = ceil((row-miny)/gres);
+%     goal = [gx,gy];
+%     goal.parent = [gx,gy];
+%     goal.precost = 0;
+%     goal.postcost = inf;
+    goal = [row,col];
+    costmap = 0*obmap; 
+    dim = size(obmap);     
+    for i = 1:dim(1)
+        for j = 1:dim(2)
+            if obmap(i,j) == 1
+                costmap(i,j) = inf;
+                continue
+            elseif i == col && j == row
+                continue
+            end            
+            start = [i,j];
+            cost = AStarSearch(start,goal,obmap);
+            costmap(i,j) = cost;
+        end
+    end    
+end
+
+function cost = AStarSearch(start,goal,obmap)
+    dim = size(obmap);
+    % Grids(i,j,1) - x of parent pos; 2 - y of parent pos; 3 - precost; 4 -
+    % postcost
+    Grids = zeros(dim(1),dim(2),4);
+    for i = 1:dim(1)
+        for j = 1:dim(2)
+            Grids(i,j,1) = i; % 父节点的所在行
+            Grids(i,j,2) = j; % 父节点的所在列
+            Grids(i,j,3) = norm(([i,j]-goal)); % 启发值h
+            Grids(i,j,4) = inf; % g值
+        end
+    end
+    Open = [start];
+    Grids(start(1),start(2),4) = 0;
+    Close = [];
+    while ~isempty(Open)
+        [wknode,Open] = PopOpen(Open,Grids);
+        [Grids,Open,Close] = Update(wknode,goal,obmap,Grids,Open,Close);
+        Close(end+1,:) = wknode;
+    end
+    cost = Grids(goal(1),goal(2),3)+Grids(goal(1),goal(2),4);
+end
+
+function [Grids,Open,Close] = Update(wknode,goal,obmap,Grids,Open,Close)
+    dim = size(obmap);
+    for i = -1:1
+        for j = -1:1
+            adjnode = wknode+[i,j];
+            row = adjnode(1);
+            col = adjnode(2);
+            if i == 0 && j == 0
+                continue
+            elseif row < 1 || row > dim(1)
+                continue
+            elseif col < 1 || col > dim(2)
+                continue
+            elseif obmap(row,col) == 1
+                continue
+            end
+            tcost = Grids(wknode(1),wknode(2),4)+norm([i,j]);
+            if Grids(row,col,4) > tcost
+                Grids(row,col,1) = wknode(1);
+                Grids(row,col,2) = wknode(2);
+                Grids(row,col,4) = tcost;
+                % add adjnode to Open except wknode is goal
+                if ~ismember(adjnode,Open,'rows') && ~isequal(adjnode,goal)
+                    Open(end+1,:) = adjnode;
+                end
+                % if adjnode is in Close remove it
+                if isempty(Close)
+                    % do nothing
+                elseif ismember(adjnode,Close,'rows')
+                    [~,rIdx] = ismember(adjnode,Close,'rows');
+                    Close(rIdx,:) = [];
+                end
+            end
+        end
+    end
+end
+
+function [wknode,Open] = PopOpen(Open,Grids)
+    mincost = inf;
+    minidx = 1;
+    for i = 1:size(Open,1)
+        node = Open(i,:);
+        tcost = Grids(node(1),node(2),3)+Grids(node(1),node(2),4);
+        if tcost < mincost
+            minidx = i;
+            mincost = tcost;
+        end
+    end
+    wknode = Open(minidx,:);
+    Open(minidx,:) = [];
+end
+
+function [minx,miny,obmap] = CalcObstMap(obstlist,gres)
+    minx = min(obstlist(:,1));
+    maxx = max(obstlist(:,1));
+    miny = min(obstlist(:,2));
+    maxy = max(obstlist(:,2));
+    xwidth = maxx - minx;
+    xwidth = ceil(xwidth/gres);
+    ywidth = maxy - miny;
+    ywidth = ceil(ywidth/gres);
+    obmap = zeros(ywidth,xwidth);
+    for i = 1:ywidth
+        for j = 1:xwidth
+            ix = minx+(j-1/2)*gres;
+            iy = miny+(i-1/2)*gres;
+            [~,D] = knnsearch(obstlist,[ix,iy]);
+            if D < 0.5
+                obmap(i,j) = 1;
+            end
+        end
+    end
+end
+
+% function [xidx,yidx] = CalcIdx(x,y,minx,miny,gres)
+%     xidx = ceil((x-minx)/gres);
+%     yidx = ceil((y-miny)/gres);
+% end

--- a/HybridAStar.m
+++ b/HybridAStar.m
@@ -1,0 +1,418 @@
+function [x,y,th,D,delta] = HybridAStar(Start,End,Vehicle,Configure)  
+    veh = Vehicle;
+    cfg = Configure;
+    mres = cfg.MOTION_RESOLUTION; % motino resolution 
+    
+    % 把起始的位姿(x,y,theta)转换为grid上的栅格索引
+    [isok,xidx,yidx,thidx] = CalcIdx(Start(1),Start(2),Start(3),cfg);
+    if isok % 把位姿栅格定义为一个结点，形成链表结构
+        tnode = Node(xidx,yidx,thidx,mres,0,Start(1),Start(2),Start(3),[xidx,yidx,thidx],0);
+    end
+    Open = [tnode]; % hybrid A*的Open集合
+    Close = [];
+%     [isok,xidx,yidx,thidx] = CalcIdx(End(1),End(2),End(3),cfg);
+%     if isok
+%         goal = Node(xidx,yidx,thidx,0,0,End,inf);
+%     end
+    x = [];
+    y = [];
+    th = [];
+    D = [];
+    delta = [];
+    while ~isempty(Open)
+        % pop the least cost node from open to close
+        [wknode,Open] = PopNode(Open,cfg);
+        [isok1,idx] = inNodes(wknode,Close);
+        
+        % 判断是否在Close集合内
+        if isok1
+            Close(idx) = wknode;
+        else
+            Close = [Close, wknode];
+        end
+
+        % 以wknode为根节点生成搜索树，使用Reeds-Shepp方法基于车辆单轨模型进行运动学解析拓展子结点
+        [isok2,path] = AnalysticExpantion([wknode.x,wknode.y,wknode.theta],End,veh,cfg);
+        if  isok2
+            %把wknode从idx移到Close集合最后面
+            if isok1
+                Close(end+1) = wknode;
+                Close(idx) = [];
+            else
+            end
+            [x,y,th,D,delta] = getFinalPath(path,Close,veh,cfg);
+            break % 如果能直接得到RS曲线，则跳出while循环
+        end
+        [Open,Close] = Update(wknode,Open,Close,veh,cfg); % 使用
+    end
+%     [isok,path] = AnalysticExpantion(Start,End,Vehicle,Configure);
+end
+
+function [x,y,th,D,delta] = getFinalPath(path,Close,veh,cfg)
+    wknode = Close(end); % RS曲线中最后一个元素是目标点
+    Close(end) = [];
+    nodes = [wknode];
+    % 找目标点wknode的parent,回溯，直到Close集合为空
+    while ~isempty(Close)
+        n = length(Close);
+        parent = wknode.parent;
+        % 计算从目标返回到起始点的路径点序列，放入nodes中
+        for i = n:-1:1
+            flag = 0; % 只有赋值，没有使用
+            tnode = Close(i);
+            if tnode.xidx == parent(1)...
+                    && tnode.yidx == parent(2)...
+                    && tnode.yawidx == parent(3)
+                nodes(end+1) = tnode;
+                wknode = tnode;
+                flag = 1;
+                break
+            end
+        end
+        Close(i) = [];        
+    end
+    rmin = veh.MIN_CIRCLE;
+    smax = veh.MAX_STEER;
+    mres = cfg.MOTION_RESOLUTION;
+    gres = cfg.XY_GRID_RESOLUTION;
+    % decrease one step, caz node origin is consider in
+    nlist = floor(gres*1.5/cfg.MOTION_RESOLUTION)+1; % 固定值31，和栅格的索引是选取线的交点还是选取栅格中心有关，floor是朝负无穷大四舍五入     % 每条轨迹大概是2米的长度。这里乘以1.5是确保下一个末端状态肯定在另一个栅格中，不会还在一个栅格中！在地图栅格中子结点拓展。比如对角线长度是1.4，此时还是在同一个栅格中
+    x = [];
+    y = [];
+    th = [];
+    D = [];
+    delta = [];
+    flag = 0;
+    % 路径要么是纯RS路径，要么是由RS路径和混合A*组合一起来的路径，先处理混合A*的结点，最后处理RS路径，肯定有RS路径
+    if length(nodes) >= 2
+        % 不是纯的RS路径，而是由RS路径和混合A*组合一起来的路径，>=2这些节点都是混合A*搜出来的
+        for i = length(nodes):-1:2
+            tnode = nodes(i);
+            ttnode = nodes(i-1); % parent of i
+            % initial point
+            px = tnode.x;
+            py = tnode.y;
+            pth = tnode.theta;
+            x = [x, px];
+            y = [y, py];
+            th = [th, pth];
+            D = [D, ttnode.D];
+            delta = [delta, ttnode.delta];
+            for idx = 1:nlist
+                [px,py,pth] = VehicleDynamic(px,py,pth,ttnode.D,ttnode.delta,veh.WB);
+                x = [x, px];
+                y = [y, py];
+                th = [th, pth];
+                D = [D, ttnode.D];
+                delta = [delta, ttnode.delta];
+            end
+            % 删除点，为RS路径做准备
+            if i ~= 2
+                x(end) = [];
+                y(end) = [];
+                th(end) = [];
+                D(end) = [];
+                delta(end) = [];
+            end
+        end
+    else
+        % 最后一个结点是纯的RS路径终点
+        flag = 1;
+        tnode = nodes(1);
+        px = tnode.x;
+        py = tnode.y;
+        pth = tnode.theta;
+        x = [x, px];
+        y = [y, py];
+        th = [th, pth];
+    end
+    % 此时已经搜完了全部路径，最后肯定有一段是RS路径
+    types = path.type;
+    t = rmin*path.t;
+    u = rmin*path.u;
+    v = rmin*path.v;
+    w = rmin*path.w;
+    segs = [t,u,v,w,rmin*path.x;];% avoid duplicate of x
+    for i = 1:5
+        if segs(i) == 0
+            continue
+        end
+        s = sign(segs(i)); % 前进或后退
+        
+        if types(i) == 'S'          
+            tdelta = 0;
+        elseif types(i) == 'L'
+            tdelta = smax;
+        elseif types(i) == 'R'
+            tdelta = -smax;
+        else
+            % do nothing
+        end
+        if flag == 1
+            % initialization if only rs path
+            D = [D, s*mres];
+            delta = [delta, tdelta];
+            flag = 0;
+        end
+        % 根据RS曲线路径的输入，基于运动学公式计算RS曲线上每个路径点的状态x,y,th
+        for idx = 1:round(abs(segs(i))/mres) % 四舍五入为最近的小数或整数
+           	[px,py,pth] = VehicleDynamic(px,py,pth,s*mres,tdelta,veh.WB); % s*mres中s代表前进和后退
+            x = [x, px];
+            y = [y, py];
+            th = [th, pth];
+            D = [D, s*mres];
+            delta = [delta, tdelta];         
+        end
+    end
+end
+
+function [Open,Close] = Update(wknode,Open,Close,veh,cfg)
+    mres = cfg.MOTION_RESOLUTION; % motino resolution    
+    smax = veh.MAX_STEER; % 0.6[rad],maximum steering angle
+    sres = smax/cfg.N_STEER; % 20,steering resolution  
+    % all possible control input，
+    for D = [-mres,mres] % D是0.1m,正负代表前进或后退,车辆当前位置的后轴中心与下一个位置的后轴中心之间的直线距离，有2个子结点
+        for delta = [-smax:sres:-sres,0,sres:sres:smax] % delta是转向角，分辨率是0.03[rad]，[-0.6,0.6],有21个子结点(包含0[rads])
+            [isok,tnode] = CalcNextNode(wknode,D,delta,veh,cfg); % 计算wknode的所有子结点，一共2*21=42个，此函数是根据固定的D和delta计算wknode沿着一条路径的所有子结点，tnode是此条路径的末端点
+            if isok == false % 子结点不可行
+                continue
+            end
+            [isok,~] = inNodes(tnode,Close);% 在Close集合中
+            if isok
+                continue
+            end 
+            % 拓展的节点如果在Open中比较f值;若不在则添加到Open中
+            [isok,idx] = inNodes(tnode,Open);
+            if isok
+                % 与之前的cost比较，进行更新
+                tcost = TotalCost(tnode,cfg);
+                ttnode = Open(idx);
+                ttcost = TotalCost(ttnode,cfg);
+                if tcost < ttcost
+                    Open(idx) = tnode;
+                end
+            else
+                Open(end+1) = tnode;
+            end           
+        end
+    end  
+end
+
+function [isok,idx] = inNodes(node,nodes)
+    for i = 1:length(nodes)
+        tnode = nodes(i);
+        if node.xidx == tnode.xidx...
+                && node.yidx == tnode.yidx...
+                && node.yawidx == tnode.yawidx
+            idx = i;
+            isok = true;
+            return
+        end
+    end
+    idx = 1;
+    isok = false;
+end
+
+% 根据D和delta计算wknode沿着一条路径的所有子结点
+function [isok,tnode] = CalcNextNode(wknode,D,delta,veh,cfg)
+    px = wknode.x;
+    py = wknode.y;
+    pth = wknode.theta;
+    gres = cfg.XY_GRID_RESOLUTION;
+    obstline = cfg.ObstLine;
+    % 每条轨迹大概是2米的长度。这里乘以1.5是确保下一个末端状态肯定在另一个栅格中，不会还在一个栅格中！在地图栅格中子结点拓展。比如对角线长度是1.4，此时还是在同一个栅格中
+    nlist = floor(gres*1.5/cfg.MOTION_RESOLUTION)+1; %此处是定值31， 计算给定D和delta下，沿着一条路径上wknode的子结点的数目，以便填充数据     % 每条轨迹大概是2米的长度。这里乘以1.5是确保下一个末端状态肯定在另一个栅格中，不会还在一个栅格中！在地图栅格中子结点拓展。比如对角线长度是1.4，此时还是在同一个栅格中
+    x = zeros(1,nlist+1);
+    y = x;
+    th = x;
+    x(1) = px;
+    y(1) = py;
+    th(1) = pth;
+    for idx = 1:nlist % 根据当前的状态和给定的控制，计算此条路径上的连着的车辆状态，根据上一时刻计算下一时刻
+        [px,py,pth] = VehicleDynamic(px,py,pth,D,delta,veh.WB);
+        x(idx+1) = px; % x,y,th储存了数据，但是没用到变量
+        y(idx+1) = py;
+        th(idx+1) = pth;
+        if rem(idx,5) == 0 % 每隔5个点进行一次碰撞检测
+            tvec = [px,py,pth];
+            isCollision = VehicleCollisionCheck(tvec,obstline,veh);
+            if isCollision
+                break
+            end
+        end
+    end
+    tnode = wknode;
+    if isCollision
+        isok = false;
+        return
+    else
+%         plot(x,y);
+        [isok,xidx,yidx,thidx] = CalcIdx(px,py,pth,cfg); % 把路径末端点的实际坐标转换为栅格坐标
+        if isok == false
+            return
+        else
+            cost = wknode.cost;
+            if D > 0 % 前进
+                cost = cost + gres*1.5; % 每条轨迹大概是2米的长度。这里乘以1.5是确保下一个末端状态肯定在另一个栅格中，不会还在一个栅格中！在地图栅格中子结点拓展。比如对角线长度是1.4，此时还是在同一个栅格中
+            else % 后退
+                cost = cost + cfg.BACK_COST*gres*1.5;
+            end
+            if D ~= wknode.D
+                cost = cost + cfg.SB_COST;
+            end
+            cost = cost + cfg.STEER_COST*abs(delta);
+            cost = cost + cfg.STEER_CHANGE_COST*abs(delta-wknode.delta);
+            tnode = Node(xidx,yidx,thidx,D,delta,px,py,pth,...
+                [wknode.xidx,wknode.yidx,wknode.yawidx],cost); % tnode是路径的末端点，cost为到当前状态到此路径末端状态的成本
+        end         
+    end
+end
+
+function [wknode,nodes] = PopNode(nodes,cfg)
+    mincost = inf;
+    minidx = 1;
+    gres = cfg.XY_GRID_RESOLUTION;
+    for idx = 1:length(nodes)
+        tnode = nodes(idx);
+        % x in the col y in row
+        tcost = TotalCost(tnode,cfg);
+        if tcost < mincost
+            mincost = tcost;
+            minidx = idx;
+        end
+    end
+    wknode = nodes(minidx);
+    nodes(minidx) = [];
+end
+
+function cost = TotalCost(wknode,cfg)
+    gres = cfg.XY_GRID_RESOLUTION;
+    costmap = cfg.ObstMap;
+    % 从栅格中心到目标
+    cost = cfg.H_COST*costmap(wknode.yidx,wknode.xidx); % 无障碍碰撞地图上的成本，用A*搜出来的，二维地图，没用航向
+    % 从当前结点到栅格中心
+    xshift = wknode.x - (gres*(wknode.xidx-0.5)+cfg.MINX); % 栅格的index是线的交点，而不是栅格的中心,在求坐标时所以会有减0.5
+    yshift = wknode.y - (gres*(wknode.yidx-0.5)+cfg.MINY);
+    cost = cost+cfg.H_COST*norm([xshift,yshift]);
+    % f = g + h
+    cost = wknode.cost + cost;
+end
+
+function [isok,path] = AnalysticExpantion(Start,End,Vehicle,Configure)
+    isok = true;
+    isCollision = false;
+    
+    % 将起点转换到原点计算轨迹，变换坐标系了
+    pvec = End-Start;
+    x = pvec(1);
+    y = pvec(2);
+    phi = Start(3);
+    phi = mod2pi(phi);
+    dcm = angle2dcm(phi, 0, 0); % 起点start坐标系在基坐标系下的方向余弦矩阵
+    % dcm*x 表示将基坐标中的x表示到旋转后的坐标系中，即计算坐标旋转后各向量在新坐标中的表示
+    tvec = dcm * [x; y ; 0]; % 计算坐标旋转后各向量在起点start坐标中的表示
+    x = tvec(1);
+    y = tvec(2);
+    veh = Vehicle;
+    cfg = Configure;
+    rmin = veh.MIN_CIRCLE;
+    smax = veh.MAX_STEER;
+    mres = cfg.MOTION_RESOLUTION;
+    obstline = cfg.ObstLine;
+    
+    % 看是否从当前点到目标点存在无碰撞的Reeds-Shepp轨迹，前面pvec=End-Start;的意义就在这里，注意！这里的x,y,prev(3)是把起点转换成以start为原点坐标系下的坐标
+    path = FindRSPath(x,y,pvec(3),veh);
+
+    % 以下是根据路径点和车辆运动学模型计算位置，检测是否会产生碰撞，返回isok的值。对每段路径从起点到终点按顺序进行处理，这一个线段的终点pvec是下一个线段的起点px,py,pth，  
+    types = path.type;
+    t = rmin*path.t;
+    u = rmin*path.u;
+    v = rmin*path.v;
+    w = rmin*path.w;
+    x = rmin*path.x;
+    segs = [t,u,v,w,x];
+    pvec = Start;
+    for i = 1:5
+        if segs(i) ==0
+            continue
+        end
+        px =pvec(1);
+        py = pvec(2);
+        pth = pvec(3);
+        s = sign(segs(i)); % 符号函数,判断此段运动方向是前进还是后退
+        
+        % 根据车辆的2*3种运动类型(前后2种，转向3种)，设置D和delta
+        D = s*mres; % 分辨率的正负
+        if types(i) == 'S'
+            delta = 0;
+        elseif types(i) == 'L'
+            delta = smax;
+        elseif types(i) == 'R'
+            delta = -smax;
+        else
+            % do nothing
+        end
+        
+        % 把此段的路径离散成为路点，即栅格索引,然后为路点，然后检测是否存在障碍物碰撞问题
+        for idx = 1:round(abs(segs(i))/mres) % round()四舍五入
+            % D和delta是固定，说明转弯的时候是按固定半径的圆转弯
+           	[px,py,pth] = VehicleDynamic(px,py,pth,D,delta,veh.WB);
+            if rem(idx,5) == 0 % rem(a,b)，返回用 a/b后的余数，每5个点，即0.5m检查下是否碰撞
+                tvec = [px,py,pth];
+                isCollision = VehicleCollisionCheck(tvec,obstline,veh);
+                if isCollision
+                    break
+                end
+            end
+         end
+        if isCollision
+            isok = false;
+            break % 如果路径存在碰撞则舍弃此条Reeds-Shepp路径
+        end
+        pvec = [px,py,pth];
+    end
+    % 终点位姿小于期望阈值也舍弃
+    if (mod2pi(pth) - End(3)) > deg2rad(5)
+        isok = false;
+    end
+end
+
+% 根据当前位姿和输入,计算下一位置的位姿
+function [x,y,theta] = VehicleDynamic(x,y,theta,D,delta,L)
+    x = x+D*cos(theta); % 运动学公式： x_dot = v_x * cos(theta); x_dot * t = v_x * t * cos(theta),在采样时间t内,则有x = x + v_x * t * cos(theta)，其中v_x * t=D
+    y = y+D*sin(theta); % 运动学公式
+    theta = theta+D/L*tan(delta); % L是轴距,航向变化,theta_dot=v/R,R=L/tan(delta)
+    theta = mod2pi(theta);
+end
+
+% 把位姿(x,y,theta)转换为grid上的栅格索引,如果不符合实际则isok=false
+function [isok,xidx,yidx,thidx] = CalcIdx(x,y,theta,cfg)
+    gres = cfg.XY_GRID_RESOLUTION;
+    yawres = cfg.YAW_GRID_RESOLUTION;
+    xidx = ceil((x-cfg.MINX)/gres);
+    yidx = ceil((y-cfg.MINY)/gres);
+    theta = mod2pi(theta); % 控制theta范围在[-pi,pi]区间
+    thidx = ceil((theta-cfg.MINYAW)/yawres);
+    isok = true;
+    if xidx <=0 || xidx > ceil((cfg.MAXX-cfg.MINX)/gres)
+        isok = false;
+        return
+    elseif yidx <=0 || yidx > ceil((cfg.MAXY-cfg.MINY)/gres)
+        isok = false;
+        return
+    end
+    costmap = cfg.ObstMap;
+    if costmap(yidx,xidx) == inf
+        isok = false;
+    end
+end
+
+% 把弧度x控制在[-pi,pi]
+function v = mod2pi(x)
+    v = rem(x,2*pi); % 求整除x/2pi的余数
+    if v < -pi
+        v = v+2*pi;
+    elseif v > pi
+        v = v-2*pi;
+    end
+end

--- a/Node.m
+++ b/Node.m
@@ -1,0 +1,28 @@
+classdef Node
+    properties
+        xidx = 0;
+        yidx = 0;
+        yawidx = 0;
+        D = 0;
+        delta = 0;
+        x = 0;
+        y = 0;
+        theta = 0;
+        parent = [0,0,0];
+        cost = inf;
+    end
+    methods
+        function obj = Node(xidx,yidx,yawidx,D,delta,x,y,theta,parent,cost) % 构造函数，声明的时候就定义了
+            obj.xidx = xidx;
+            obj.yidx = yidx;
+            obj.yawidx = yawidx;
+            obj.D = D;
+            obj.delta = delta;
+            obj.x = x;
+            obj.y = y;
+            obj.theta = theta;
+            obj.parent = parent;
+            obj.cost = cost;
+        end
+    end
+end

--- a/RSPath.m
+++ b/RSPath.m
@@ -1,0 +1,44 @@
+classdef RSPath
+    properties (Constant)
+        Types = [   
+            'L', 'R', 'L', 'N', 'N' ;           %1
+            'R', 'L', 'R', 'N', 'N' ;           %2
+            'L', 'R', 'L', 'R', 'N' ;           %3
+            'R', 'L', 'R', 'L', 'N' ;           %4
+            'L', 'R', 'S', 'L', 'N' ;           %5
+            'R', 'L', 'S', 'R', 'N' ;           %6
+            'L', 'S', 'R', 'L', 'N' ;           %7
+            'R', 'S', 'L', 'R', 'N' ;           %8
+            'L', 'R', 'S', 'R', 'N' ;           %9
+            'R', 'L', 'S', 'L', 'N' ;           %10
+            'R', 'S', 'R', 'L', 'N' ;           %11
+            'L', 'S', 'L', 'R', 'N' ;           %12
+            'L', 'S', 'R', 'N', 'N' ;           %13
+            'R', 'S', 'L', 'N', 'N' ;           %14
+            'L', 'S', 'L', 'N', 'N' ;           %15
+            'R', 'S', 'R', 'N', 'N' ;           %16
+            'L', 'R', 'S', 'L', 'R' ;           %17
+            'R', 'L', 'S', 'R', 'L'             %18
+            ];
+    end
+    properties
+        type = repmat('N',[1,5]); % 重复数组副本，即['N','N','N','N','N']
+        t = 0; %以下5个变量分别代表type中对应操作方式的路径距离
+        u = 0;
+        v = 0;
+        w = 0;
+        x = 0;
+        totalLength = 0;
+    end
+    methods
+        function obj = RSPath(type,t,u,v,w,x) % 构造函数
+            obj.type = type;
+            obj.t = t;
+            obj.u = u;
+            obj.v = v;
+            obj.w = w;
+            obj.x = x;
+            obj.totalLength = sum(abs([t,u,v,w,x]));
+        end
+    end
+end

--- a/VehicleAnimation.m
+++ b/VehicleAnimation.m
@@ -1,0 +1,70 @@
+function VehicleAnimation(x,y,theta,cfg,veh)
+    sz=get(0,'screensize');
+    figure('outerposition',sz);
+    videoFWriter = VideoWriter('Parking.mp4','MPEG-4');
+    open(videoFWriter);
+    ObstList = cfg.ObstList;
+    scatter(ObstList(:,1),ObstList(:,2),10,'r') % 画散点图
+    hold on
+    axis equal
+    xlim([cfg.MINX,cfg.MAXX]);
+    ylim([cfg.MINY,cfg.MAXY]);
+    plot(x,y,'b') % 规划出来的轨迹，蓝色曲线   
+    px = x(1);
+    py = y(1);
+    pth = theta(1);
+    [vehx,vehy] = getVehTran(px,py,pth,veh); % 根据后轴中心的位姿计算车辆边框的位姿
+    h1 = plot(vehx,vehy,'k'); % 车辆边框
+    h2 = plot(px,px,'rx','MarkerSize',10); % 车辆后轴中心
+    img = getframe(gcf);
+    writeVideo(videoFWriter,img);
+    for i = 2:length(theta)
+        px = x(i);
+        py = y(i);
+        pth = theta(i);
+        [vehx,vehy] = getVehTran(px,py,pth,veh);
+        h1.XData = vehx; % 更新h1图像句柄,把车辆边框四个角点的x坐标添加进去
+        h1.YData = vehy;
+        h2.XData = px; % 更新h2图像句柄,把车辆边框四个角点的y坐标添加进去
+        h2.YData = py;
+        img = getframe(gcf);
+        writeVideo(videoFWriter,img);
+%         pause(0.005)
+    end
+    close(videoFWriter);
+end
+
+ % 根据后轴中心的位姿计算车辆边框的位姿
+function [x,y] = getVehTran(x,y,theta,veh)
+    W = veh.W;
+    LF = veh.LF;
+    LB = veh.LB;
+    
+    % 车辆的边框由四个角点确定
+    Cornerfl = [LF, W/2]; % 左前方角点
+    Cornerfr = [LF, -W/2]; % 右前方角点
+    Cornerrl = [-LB, W/2]; % 左后方角点
+    Cornerrr = [-LB, -W/2]; % 右后方角点
+    Pos = [x,y]; % 后轴中心坐标
+    dcm = angle2dcm(-theta, 0, 0); % 计算四个角点的旋转矩阵,由于是刚体的一部分，旋转矩阵相同，将角度转换为方向余弦矩阵，旋转顺序是ZYX
+    
+    tvec = dcm*[Cornerfl';0]; % 旋转变换，Cornerfl旋转后形成的列向量，位置向量3*1，最后一个是z坐标
+    tvec = tvec';
+    Cornerfl = tvec(1:2)+Pos; % 平移变换
+    
+    tvec = dcm*[Cornerfr';0];
+    tvec = tvec';
+    Cornerfr = tvec(1:2)+Pos;
+    
+    tvec = dcm*[Cornerrl';0];
+    tvec = tvec';
+    Cornerrl = tvec(1:2)+Pos;
+    
+    tvec = dcm*[Cornerrr';0];
+    tvec = tvec';
+    Cornerrr = tvec(1:2)+Pos;
+    
+    % 返回车辆边框四个角点的x,y坐标
+    x = [Cornerfl(1),Cornerfr(1),Cornerrr(1),Cornerrl(1),Cornerfl(1)];
+    y = [Cornerfl(2),Cornerfr(2),Cornerrr(2),Cornerrl(2),Cornerfl(2)];
+end

--- a/VehicleCollisionCheck.m
+++ b/VehicleCollisionCheck.m
@@ -1,0 +1,92 @@
+function isCollision = VehicleCollisionCheck(pVec,ObstLine,Vehicle)
+    W = Vehicle.W;
+    LF = Vehicle.LF;
+    LB = Vehicle.LB;
+    Cornerfl = [LF, W/2];
+    Cornerfr = [LF, -W/2];
+    Cornerrl = [-LB, W/2];
+    Cornerrr = [-LB, -W/2];
+    Pos = pVec(1:2);
+    theta = pVec(3);
+    dcm = angle2dcm(-theta, 0, 0); % 方向余弦矩阵，负号是 把坐标转换为基坐标
+    
+    tvec = dcm*[Cornerfl';0]; % 旋转变换
+    tvec = tvec';
+    Cornerfl = tvec(1:2)+Pos; % 平移变换
+    
+    tvec = dcm*[Cornerfr';0];
+    tvec = tvec';
+    Cornerfr = tvec(1:2)+Pos;
+    
+    tvec = dcm*[Cornerrl';0];
+    tvec = tvec';
+    Cornerrl = tvec(1:2)+Pos;
+    
+    tvec = dcm*[Cornerrr';0];
+    tvec = tvec';
+    Cornerrr = tvec(1:2)+Pos;   
+    % 记录构成车辆模型的四条直线的起止坐标   
+    Rect = [];                            %  _ _ _ _ _
+    Rect(end+1,:) = [Cornerfl, Cornerfr]; % |    ^    |
+    Rect(end+1,:) = [Cornerfr, Cornerrr]; % |    ^    |
+    Rect(end+1,:) = [Cornerrr, Cornerrl]; % |    ^    |
+    Rect(end+1,:) = [Cornerrl, Cornerfl]; % | _ _^ _ _|
+    obs_self_define=[-25, 30; 25, 30; 25, 5; 10, 5; 10, 0; -10, 0; -10, 5; -25, 5; -25, 30]; % 手动根据地图修改障碍物线段,地图变换时需要修改此数据
+    isCollision = false;
+    for i = 1:length(ObstLine)
+        [xi,yi] = polyxpoly([Rect(:,1);Rect(1,1)],[Rect(:,2);Rect(1,2)],obs_self_define(:,1),obs_self_define(:,2)); % 检测车身是否与边界相交
+        if isempty(xi)==0
+            isCollision = true;
+        end
+        if isCollision == true
+            return
+        end
+    end
+end
+
+function isCollision = RectLineCollisionCheck(Rect, Line)
+    isCollision = SATCheckObj2Line(Rect, Line, Line);
+    if isCollision == false
+        return
+    else
+        isCollision = SATCheckObj2Line(Rect, Line, Rect(1,:));
+        if isCollision == false
+            return
+        else
+            isCollision = SATCheckObj2Line(Rect, Line, Rect(2,:));
+        end
+    end
+end
+
+function isCollision = SATCheckObj2Line(Object, workLine, refLine)
+    theta = atan2(refLine(4)-refLine(2),refLine(3)-refLine(1));
+    dcm = angle2dcm(theta, 0, 0);
+    % dcm*x 表示将基坐标中的x表示到旋转后的坐标系中，即计算坐标旋转后各向量在新坐标中的表示
+    pStart = dcm*[workLine(1:2)'; 0];
+    pEnd = dcm*[workLine(3:4)'; 0];
+    LineMinx = min(pStart(1), pEnd(1));
+    LineMaxx = max(pStart(1), pEnd(1));
+    LineMiny = min(pStart(2), pEnd(2));
+    LineMaxy = max(pStart(2), pEnd(2));
+    % To find the max and min corrdination of object
+    dim = size(Object);
+    objLineMinx = inf;
+    objLineMaxx = 0;
+    objLineMiny = inf;
+    objLineMaxy = 0;
+    for i = 1:dim(1)
+        objpStart = dcm*[Object(i,1:2) 0]';
+        objpEnd = dcm*[Object(i,3:4) 0]';
+        objLineMinx = min([objLineMinx, objpStart(1), objpEnd(1)]);
+        objLineMaxx = max([objLineMaxx, objpStart(1), objpEnd(1)]);
+        objLineMiny = min([objLineMiny, objpStart(2), objpEnd(2)]);
+        objLineMaxy = max([objLineMaxy, objpStart(2), objpEnd(2)]);
+    end
+
+    isCollision = true;
+    if LineMinx > objLineMaxx || LineMaxx < objLineMinx || ...
+            LineMiny > objLineMaxy || LineMaxy < objLineMiny
+        isCollision = false;
+        return
+    end
+end


### PR DESCRIPTION
1.HybridAStar函数中第25与第35行的标志位命名重复，造成部分路径点被删除，修改名称增加判断即可； 2.原代码中的RS曲线CCCC类路径的生成有问题，对照RS论文中公式发现与代码一致，猜测是论文中的公式有误，要得到正确的结果可采用matlab的Navigation Toolbox中的reedsSheppConnection系列函数生成RS曲线即可（matlab需要安装Navigation Toolbox）。