### PR TITLE
修复了标志位复用造成的Node被删除问题

### DIFF
--- a/src/HybridAStar.m
+++ b/src/HybridAStar.m
@@ -321,7 +321,7 @@ function [isok,path] = AnalysticExpantion(Start,End,Vehicle,Configure)
     obstline = cfg.ObstLine;
     
     % 看是否从当前点到目标点存在无碰撞的Reeds-Shepp轨迹，前面pvec=End-Start;的意义就在这里，注意！这里的x,y,prev(3)是把起点转换成以start为原点坐标系下的坐标
-    path = FindRSPath_plus(x,y,pvec(3),veh);
+    path = FindRSPath(x,y,pvec(3),veh);
 
     % 以下是根据路径点和车辆运动学模型计算位置，检测是否会产生碰撞，返回isok的值。对每段路径从起点到终点按顺序进行处理，这一个线段的终点pvec是下一个线段的起点px,py,pth，  
     types = path.type;


### PR DESCRIPTION
1.HybridAStar函数中第25与第35行的标志位命名重复，造成部分路径点被删除，修改名称增加判断即可； 2.原代码中的RS曲线CCCC类路径的生成有问题，对照RS论文中公式发现与代码一致，猜测是论文中的公式有误，要得到正确的结果可采用matlab的Navigation Toolbox中的reedsSheppConnection系列函数生成RS曲线即可（matlab需要安装Navigation Toolbox）。